### PR TITLE
Correct `watch` command in readme

### DIFF
--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -19,7 +19,7 @@ Then you can automatically create symlinks to your built files by running
 When you're developing you can have your files automatically rebuild by keeping
 
 ```bash
-{{packageManager}} run dev
+{{packageManager}} run watch
 ```
 
 running in the background. If you've already built symlinks, your up-to-date script can be run instantly by entering `{{kebab name}}` into the KoLmafia CLI.


### PR DESCRIPTION
This PR fixes the README to reflect implementation -- It also adds a newline to the end of the final line.